### PR TITLE
fix: default display css

### DIFF
--- a/src/DebugBar/Resources/debugbar.css
+++ b/src/DebugBar/Resources/debugbar.css
@@ -1,7 +1,4 @@
 /* Hide debugbar when printing a page */
-div.phpdebugbar {
-  display: none;
-}
 @media print {
   div.phpdebugbar {
     display: none;

--- a/src/DebugBar/Resources/debugbar.js
+++ b/src/DebugBar/Resources/debugbar.js
@@ -491,7 +491,6 @@ if (typeof(PhpDebugBar) == 'undefined') {
             }
 
             var self = this;
-            this.$el.css('display', 'block');
             this.$el.appendTo('body');
             this.$dragCapture = $('<div />').addClass(csscls('drag-capture')).appendTo(this.$el);
             this.$resizehdle = $('<div />').addClass(csscls('resize-handle')).appendTo(this.$el);


### PR DESCRIPTION
Alternative to #2
> this part breaks the .hide() on iframes

>also why `display:block`??
>I think this is not necessary, why `display:none`??
>Wouldn't it work the same without these parts? some reason?

**UPDATE:** This also fix print mode
